### PR TITLE
New `videoplaying` event

### DIFF
--- a/src/OpusMediaRecorder.js
+++ b/src/OpusMediaRecorder.js
@@ -689,7 +689,7 @@ class OpusMediaRecorder extends EventTarget {
   'pause', // Called to handle the pause event.
   'resume', // Called to handle the resume event.
   'error', // Called to handle a MediaRecorderErrorEvent.
-  'playingvideo' // Called when internal video elements begin playing
+  'videoplaying' // Called when internal video elements begin playing
 ].forEach(name => defineEventAttribute(OpusMediaRecorder.prototype, name));
 
 // MS Edge specific monkey patching:


### PR DESCRIPTION
Adds new `videoplaying` event in event handling system, called when an internally-created `video` element begins playing.